### PR TITLE
Remove InMemory EF Core package reference

### DIFF
--- a/ToDo.Api/ToDo.Api.csproj
+++ b/ToDo.Api/ToDo.Api.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This commit removes the package reference for
`Microsoft.EntityFrameworkCore.InMemory` version `9.0.8` from the `ToDo.Api.csproj` project file.